### PR TITLE
ci: update golangci-lint installation and renovate config for version management

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,7 +17,7 @@
   "suppressNotifications": [
     "prIgnoreNotification"
   ],
-  "rebaseWhen": "conflicted",
+  "rebaseWhen": "behind-base-branch",
   "commitBodyTable": true,
   "labels": [
     "renovate"
@@ -100,6 +100,19 @@
         "go install (?<depName>[^@]+?)@(?<currentValue>[0-9.-a-zA-Z]+)"
       ],
       "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "description": "Update GOLANGCI_VERSION in GitHub Actions workflows",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/[^/]+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "GOLANGCI_VERSION:\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "github.com/golangci/golangci-lint/v2",
+      "datasourceTemplate": "go",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "customType": "regex",

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -19,6 +19,7 @@ on:
 
 env:
   GO_VERSION: 1.26.2
+  GOLANGCI_VERSION: 2.12.1
   PYTHON_VERSION: 3.13.3
   TASK_VERSION: 3.38.0
   TASK_X_REMOTE_TASKFILES: 1
@@ -57,7 +58,7 @@ jobs:
           go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
 
           # Install golangci-lint
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${{ env.GOLANGCI_VERSION }}
 
           # Install gocritic
           go install github.com/go-critic/go-critic/cmd/gocritic@latest


### PR DESCRIPTION
**Key Changes:**

- Switched golangci-lint installation in pre-commit workflow to use version from environment variable
- Added GOLANGCI_VERSION variable to pre-commit workflow for explicit version control
- Enhanced Renovate configuration to automate golangci-lint version updates in workflows
- Updated Renovate rebase behavior for improved PR synchronization

**Added:**

- GOLANGCI_VERSION environment variable in `.github/workflows/pre-commit.yaml` to centralize and control the golangci-lint version used in CI
- Custom Renovate regex manager in `.github/renovate.json5` to detect and update GOLANGCI_VERSION in GitHub Actions workflows

**Changed:**

- golangci-lint installation method in `.github/workflows/pre-commit.yaml` to use `go install` with the version specified by GOLANGCI_VERSION instead of the install script
- Renovate `rebaseWhen` option in `.github/renovate.json5` from `conflicted` to `behind-base-branch` to trigger rebases when the branch is behind the base