### PR TITLE
ci: bump go version to 1.26.4

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache-dependency-path: "**/*.sum"
 
       - name: Fix GOPATH

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
   GOLANGCI_VERSION: 2.12.2
   PYTHON_VERSION: 3.13.3
   TASK_VERSION: 3.38.0

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -34,7 +34,7 @@ concurrency:
 
 # Retrieve BOT_USER_ID via `curl -s "https://api.github.com/users/${BOT_USERNAME}%5Bbot%5D" | jq .id`
 env:
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
   RENOVATE_GIT_AUTHOR: "${{ secrets.BOT_USERNAME }} <${{ secrets.BOT_USER_ID }}+${{ secrets.BOT_USERNAME }}[bot]@users.noreply.github.com>"
 
 # Permissions block for GitHub App

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
 
 permissions:
   actions: read


### PR DESCRIPTION
**Key Changes:**

- Updated CI Go toolchain version from 1.26.3 to 1.26.4
- Aligned release, test, pre-commit, and Renovate workflows on the same Go patch version
- Ensured automated workflows use the latest configured Go patch release consistently

**Changed:**

- Go version configuration - Updated .github/workflows/goreleaser.yaml, .github/workflows/pre-commit.yaml, .github/workflows/renovate.yaml, and .github/workflows/tests.yaml to use Go 1.26.4 instead of 1.26.3 for consistent CI and release execution