### PR TITLE
build: update go toolchain and renovate test grouping

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -84,8 +84,8 @@
     {
       "description": "Group test dependencies",
       "matchPackageNames": [
-        "/*test*/",
-        "/*mock*/"
+        "/test/",
+        "/mock/"
       ],
       "groupName": "test dependencies"
     }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cowdogmoo/bcp
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.9


### PR DESCRIPTION
**Key Changes:**

- Updated the configured Go toolchain to the latest patch version
- Refined Renovate package matching for test and mock dependencies
- Kept dependency automation grouping aligned with intended package name patterns

**Changed:**

- Go toolchain version now targets go1.26.4 instead of go1.26.3 in go.mod
- Renovate test dependency grouping now matches package names containing test or mock using simpler regex patterns in .github/renovate.json5