### PR TITLE
ci: update codecov action version annotation

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,7 +51,7 @@ jobs:
           bash .hooks/run-go-tests.sh coverage
 
       - name: Send the coverage output
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: coverage-all.out
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
**Key Changes:**

- Updated the coverage upload step to identify the pinned Codecov action as v7
- Preserved the existing pinned action SHA to keep CI behavior deterministic
- Left coverage file and token configuration unchanged to avoid altering upload behavior

**Changed:**

- Codecov workflow metadata - Updated the version comment for the pinned `codecov/codecov-action` usage in `.github/workflows/tests.yaml` from v6 to v7 while retaining the existing SHA pin